### PR TITLE
Remove remaining schema references

### DIFF
--- a/app/services/data/cancel-top-up.js
+++ b/app/services/data/cancel-top-up.js
@@ -5,7 +5,7 @@ const claimEventEnum = require('../../constants/claim-event-enum')
 const dateFormatter = require('../date-formatter')
 
 module.exports = function (claim, caseworker) {
-  return knex('IntSchema.TopUp')
+  return knex('TopUp')
     .update({
       PaymentStatus: 'CANCELLED',
       DateAdded: dateFormatter.now().toDate()

--- a/app/services/data/get-rejection-reason-id.js
+++ b/app/services/data/get-rejection-reason-id.js
@@ -2,7 +2,7 @@ const config = require('../../../knexfile').intweb
 const knex = require('knex')(config)
 
 module.exports = function (reason) {
-  return knex('IntSchema.ClaimRejectionReason')
+  return knex('ClaimRejectionReason')
     .first('ClaimRejectionReasonId')
     .where('RejectionReason', reason)
     .then(function (result) {

--- a/app/services/data/get-rejection-reasons.js
+++ b/app/services/data/get-rejection-reasons.js
@@ -4,7 +4,7 @@ const RejectionReason = require('../domain/claim-rejection-reason')
 
 module.exports = function () {
   var rejectionReasons = []
-  return knex('IntSchema.ClaimRejectionReason')
+  return knex('ClaimRejectionReason')
     .select('ClaimRejectionReasonId', 'RejectionReason', 'IsEnabled')
     .then(function (results) {
       results.forEach(function (result) {

--- a/app/services/data/insert-deduction.js
+++ b/app/services/data/insert-deduction.js
@@ -4,7 +4,7 @@ const knex = require('knex')(config)
 module.exports = function (claimId, claimDeduction) {
   return getClaim(claimId)
     .then(function (claim) {
-      return knex('IntSchema.ClaimDeduction')
+      return knex('ClaimDeduction')
         .returning('ClaimDeductionId')
         .insert({
           EligibilityId: claim.EligibilityId,
@@ -18,7 +18,7 @@ module.exports = function (claimId, claimDeduction) {
 }
 
 function getClaim (claimId) {
-  return knex('IntSchema.Claim')
+  return knex('Claim')
     .where('ClaimId', claimId)
     .first()
 }

--- a/app/services/data/insert-top-up.js
+++ b/app/services/data/insert-top-up.js
@@ -5,7 +5,7 @@ const claimEventEnum = require('../../constants/claim-event-enum')
 const dateFormatter = require('../date-formatter')
 
 module.exports = function (claim, topup, caseworker) {
-  return knex('IntSchema.TopUp')
+  return knex('TopUp')
     .insert({
       ClaimId: claim.ClaimId,
       PaymentStatus: 'PENDING',

--- a/app/services/data/update-top-up.js
+++ b/app/services/data/update-top-up.js
@@ -5,7 +5,7 @@ const claimEventEnum = require('../../constants/claim-event-enum')
 const dateFormatter = require('../date-formatter')
 
 module.exports = function (claim, topup, caseworker) {
-  return knex('IntSchema.TopUp')
+  return knex('TopUp')
     .update({
       TopUpAmount: topup.amount,
       Reason: topup.reason,

--- a/test/e2e/advanced-search.js
+++ b/test/e2e/advanced-search.js
@@ -24,7 +24,7 @@ describe('Advanced search flow', () => {
       .then(function (ids) {
         reference1ClaimId = ids.claimId
 
-        const reference1Update = knex('IntSchema.Claim')
+        const reference1Update = knex('Claim')
           .update({
             AssistedDigitalCaseworker: 'test@test.com',
             DateOfJourney: date.toDate(),
@@ -40,7 +40,7 @@ describe('Advanced search flow', () => {
 
         return Promise.all([reference1Update, reference2Insert])
           .then(function () {
-            return knex('IntSchema.Claim')
+            return knex('Claim')
               .update({
                 DateReviewed: date.toDate()
               })

--- a/test/integration/services/data/test-get-auto-approval-config.js
+++ b/test/integration/services/data/test-get-auto-approval-config.js
@@ -92,15 +92,15 @@ function insertTestData () {
 }
 
 function setIsEnabled (autoApprovalConfigId, isEnabled) {
-  return db('IntSchema.AutoApprovalConfig')
-    .where('AlConfigId', autoApprovalConfigId)
+  return db('AutoApprovalConfig')
+    .where('AutoApprovalConfigId', autoApprovalConfigId)
     .update({
       IsEnabled: isEnabled
     })
 }
 
 function getCurrentAutoApprovalConfigId () {
-  return db('IntSchema.AutoApprovalConfig')
+  return db('AutoApprovalConfig')
     .first()
     .where('IsEnabled', true)
     .select('AutoApprovalConfigId')

--- a/test/integration/services/data/test-insert-claim-event.js
+++ b/test/integration/services/data/test-insert-claim-event.js
@@ -25,7 +25,7 @@ describe('services/data/insert-claim-event', function () {
   it('should insert a claim event', function () {
     return insertClaimEvent(REFERENCE, eligibilityId, claimId, EVENT, ADDITIONAL_DATA, NOTE, CASEWORKER, IS_INTERNAL)
       .then(function () {
-        return db.first().from('IntSchema.ClaimEvent')
+        return db.first().from('ClaimEvent')
           .where({ EligibilityId: eligibilityId, Reference: REFERENCE, ClaimId: claimId })
           .orderBy('DateAdded', 'desc')
           .then(function (claimEvent) {

--- a/test/integration/services/data/test-insert-task-send-claim-notification.js
+++ b/test/integration/services/data/test-insert-task-send-claim-notification.js
@@ -27,7 +27,7 @@ describe('services/data/insert-task-send-first-time-claim-notification', functio
   it('should insert a new task to send the first time claim notification', function () {
     return insertTaskSendClaimNotification(tasksEnum.ACCEPT_CLAIM_NOTIFICATION, reference, eligibilityId, claimId)
       .then(function () {
-        return db.first().from('IntSchema.Task').where({ Reference: reference, ClaimId: claimId })
+        return db.first().from('Task').where({ Reference: reference, ClaimId: claimId })
           .then(function (task) {
             expect(task.Task).to.equal(tasksEnum.ACCEPT_CLAIM_NOTIFICATION)
             expect(task.Reference).to.equal(reference)
@@ -42,7 +42,7 @@ describe('services/data/insert-task-send-first-time-claim-notification', functio
   it('should insert a new task to send a notification to a specific email address', function () {
     return insertTaskSendClaimNotification(tasksEnum.ACCEPT_CLAIM_NOTIFICATION, reference, eligibilityIdDoesNotExist, claimId, emailAddress)
       .then(function () {
-        return db.first().from('IntSchema.Task').where('EligibilityId', eligibilityIdDoesNotExist)
+        return db.first().from('Task').where('EligibilityId', eligibilityIdDoesNotExist)
           .then(function (task) {
             expect(task.AdditionalData).to.equal(emailAddress)
           })

--- a/test/integration/services/data/test-submit-claim-response.js
+++ b/test/integration/services/data/test-submit-claim-response.js
@@ -82,10 +82,10 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Eligibility').where('IntSchema.Eligibility.Reference', reference)
-          .join('IntSchema.Claim', 'IntSchema.Eligibility.EligibilityId', '=', 'IntSchema.Claim.EligibilityId')
-          .join('IntSchema.Visitor', 'IntSchema.Eligibility.EligibilityId', '=', 'IntSchema.Visitor.EligibilityId')
-          .join('IntSchema.Prisoner', 'IntSchema.Eligibility.EligibilityId', '=', 'IntSchema.Prisoner.EligibilityId')
+        return db('Eligibility').where('Eligibility.Reference', reference)
+          .join('Claim', 'Eligibility.EligibilityId', '=', 'Claim.EligibilityId')
+          .join('Visitor', 'Eligibility.EligibilityId', '=', 'Visitor.EligibilityId')
+          .join('Prisoner', 'Eligibility.EligibilityId', '=', 'Prisoner.EligibilityId')
           .first()
           .then(function (result) {
             expect(result.Caseworker).to.be.equal(caseworker)
@@ -103,7 +103,7 @@ describe('services/data/submit-claim-response', function () {
             expect(stubInsertTaskSendClaimNotification.calledWith(tasksEnum.REJECT_CLAIM_NOTIFICATION, reference, newIds.eligibilityId, newIds.claimId)).to.be.true //eslint-disable-line
             expect(stubUpdateRelatedClaimsRemainingOverpaymentAmount.notCalled).to.be.true //eslint-disable-line
 
-            return db('IntSchema.ClaimExpense').where('ClaimId', newIds.claimId).select()
+            return db('ClaimExpense').where('ClaimId', newIds.claimId).select()
               .then(function (claimExpenses) {
                 expect(claimExpenses[0].Status).to.be.equal(claimDecisionEnum.REJECTED)
                 expect(claimExpenses[0].ApprovedCost).to.be.equal(10)
@@ -132,7 +132,7 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Claim').where('IntSchema.Claim.Reference', reference)
+        return db('Claim').where('Claim.Reference', reference)
           .first()
           .then(function (result) {
             expect(result.DateApproved).not.to.be.null //eslint-disable-line
@@ -158,7 +158,7 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Claim').where('IntSchema.Claim.Reference', reference)
+        return db('Claim').where('Claim.Reference', reference)
           .first()
           .then(function (result) {
             expect(result.DateApproved).to.be.null //eslint-disable-line
@@ -184,7 +184,7 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Claim').where('IntSchema.Claim.Reference', reference)
+        return db('Claim').where('Claim.Reference', reference)
           .first()
           .then(function (result) {
             expect(result.DateApproved).to.be.null //eslint-disable-line
@@ -211,7 +211,7 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Prisoner').where('IntSchema.Prisoner.Reference', reference)
+        return db('Prisoner').where('Prisoner.Reference', reference)
           .first()
           .then(function (result) {
             expect(result.ReleaseDateIsSet).to.be.equal(true)
@@ -239,7 +239,7 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Prisoner').where('IntSchema.Prisoner.Reference', reference)
+        return db('Prisoner').where('Prisoner.Reference', reference)
           .first()
           .then(function (result) {
             expect(result.ReleaseDateIsSet).to.be.equal(false)
@@ -266,7 +266,7 @@ describe('services/data/submit-claim-response', function () {
 
     return submitClaimResponse(claimId, claimResponse)
       .then(function (result) {
-        return db('IntSchema.Claim').where('ClaimId', claimId).first()
+        return db('Claim').where('ClaimId', claimId).first()
       })
       .then(function (claim) {
         expect(claim.PaymentMethod).to.equal(paymentMethodEnum.MANUALLY_PROCESSED.value)

--- a/test/integration/services/data/test-update-auto-approval-config.js
+++ b/test/integration/services/data/test-update-auto-approval-config.js
@@ -116,15 +116,15 @@ function insertTestData () {
 }
 
 function setIsEnabled (autoApprovalConfigId, isEnabled) {
-  return db('IntSchema.AutoApprovalConfig')
-    .where('AlConfigId', autoApprovalConfigId)
+  return db('AutoApprovalConfig')
+    .where('AutoApprovalConfigId', autoApprovalConfigId)
     .update({
       IsEnabled: isEnabled
     })
 }
 
 function getCurrentAutoApprovalConfigId () {
-  return db('IntSchema.AutoApprovalConfig')
+  return db('AutoApprovalConfig')
     .first()
     .where('IsEnabled', true)
     .select('AutoApprovalConfigId')

--- a/test/integration/services/data/test-update-claim-overpayment-status.js
+++ b/test/integration/services/data/test-update-claim-overpayment-status.js
@@ -24,7 +24,7 @@ describe('services/data/test-update-claim-overpayment-status', function () {
     var amount = '50'
     var reason = 'Test Reason'
 
-    return db('IntSchema.Claim').first().where('ClaimId', claimId)
+    return db('Claim').first().where('ClaimId', claimId)
       .then(function (claimBefore) {
         var overpaymentResponse = {
           action: overpaymentActionEnum.OVERPAID,
@@ -35,9 +35,9 @@ describe('services/data/test-update-claim-overpayment-status', function () {
 
         return updateClaimOverpaymentStatus(claimBefore, overpaymentResponse)
           .then(function () {
-            return db('IntSchema.Claim').first().where('ClaimId', claimId)
+            return db('Claim').first().where('ClaimId', claimId)
               .then(function (claimAfter) {
-                return db('IntSchema.ClaimEvent').orderBy('DateAdded', 'desc').first().where('ClaimId', claimId)
+                return db('ClaimEvent').orderBy('DateAdded', 'desc').first().where('ClaimId', claimId)
                   .then(function (claimEvent) {
                     expect(claimAfter.IsOverpaid).to.be.true //eslint-disable-line
                     expect(claimAfter.OverpaymentAmount.toString()).to.equal(amount)
@@ -56,7 +56,7 @@ describe('services/data/test-update-claim-overpayment-status', function () {
 
     return db('Claim').where('ClaimId', claimId).update({ IsOverpaid: true })
       .then(function () {
-        return db('IntSchema.Claim').first().where('ClaimId', claimId)
+        return db('Claim').first().where('ClaimId', claimId)
           .then(function (claimBefore) {
             var overpaymentResponse = {
               action: overpaymentActionEnum.UPDATE,
@@ -67,9 +67,9 @@ describe('services/data/test-update-claim-overpayment-status', function () {
 
             return updateClaimOverpaymentStatus(claimBefore, overpaymentResponse)
               .then(function () {
-                return db('IntSchema.Claim').first().where('ClaimId', claimId)
+                return db('Claim').first().where('ClaimId', claimId)
                   .then(function (claimAfter) {
-                    return db('IntSchema.ClaimEvent').orderBy('DateAdded', 'desc').first().where('ClaimId', claimId)
+                    return db('ClaimEvent').orderBy('DateAdded', 'desc').first().where('ClaimId', claimId)
                       .then(function (claimEvent) {
                         expect(claimAfter.IsOverpaid).to.be.true //eslint-disable-line
                         expect(claimAfter.RemainingOverpaymentAmount.toString()).to.equal(remaining)
@@ -93,7 +93,7 @@ describe('services/data/test-update-claim-overpayment-status', function () {
 
     return db('Claim').where('ClaimId', claimId).update({ IsOverpaid: true })
       .then(function () {
-        return db('IntSchema.Claim').first().where('ClaimId', claimId)
+        return db('Claim').first().where('ClaimId', claimId)
           .then(function (claimBefore) {
             var overpaymentResponse = {
               action: overpaymentActionEnum.RESOLVE,
@@ -104,9 +104,9 @@ describe('services/data/test-update-claim-overpayment-status', function () {
 
             return updateClaimOverpaymentStatus(claimBefore, overpaymentResponse)
               .then(function () {
-                return db('IntSchema.Claim').first().where('ClaimId', claimId)
+                return db('Claim').first().where('ClaimId', claimId)
                   .then(function (claimAfter) {
-                    return db('IntSchema.ClaimEvent').orderBy('DateAdded', 'desc').first().where('ClaimId', claimId)
+                    return db('ClaimEvent').orderBy('DateAdded', 'desc').first().where('ClaimId', claimId)
                       .then(function (claimEvent) {
                         expect(claimAfter.IsOverpaid).to.be.false //eslint-disable-line
                         expect(claimAfter.RemainingOverpaymentAmount.toString()).to.equal(remaining)

--- a/test/integration/services/data/test-update-eligibility-trusted-status.js
+++ b/test/integration/services/data/test-update-eligibility-trusted-status.js
@@ -97,7 +97,7 @@ describe('services/data/update-eligibility-trusted-status', function () {
 })
 
 function getEligibility (eligibilityId) {
-  return db('IntSchema.Eligibility').first()
+  return db('Eligibility').first()
     .where('EligibilityId', eligibilityId)
 }
 

--- a/test/integration/services/data/test-update-file-upload-details-for-claim.js
+++ b/test/integration/services/data/test-update-file-upload-details-for-claim.js
@@ -23,7 +23,7 @@ describe('services/data/update-file-upload-details-for-claim', function () {
   it('should update the claim document', function () {
     return updateClaimDocument(claimDocumentId, testFileUpload)
       .then(function () {
-        return db('IntSchema.CLaimDocument')
+        return db('CLaimDocument')
           .first()
           .where('ClaimDocumentId', '=', claimDocumentId)
       })

--- a/test/integration/services/data/test-update-visitor-contact-details.js
+++ b/test/integration/services/data/test-update-visitor-contact-details.js
@@ -54,6 +54,6 @@ describe('services/data/update-visitor-contact-details', function () {
 })
 
 function getVisitor (eligibilityId) {
-  return db('IntSchema.Visitor').first()
+  return db('Visitor').first()
     .where('EligibilityId', eligibilityId)
 }


### PR DESCRIPTION
I've checked the schema creation and users are assigned a default schema. Seeing as not all the database queries used a schema name anyway I'm removed the other references since it makes testing easier.