### PR TITLE
Fix payments again

### DIFF
--- a/app/services/aws-helper.js
+++ b/app/services/aws-helper.js
@@ -57,7 +57,7 @@ class AWSHelper {
   }
 
   async download (key) {
-    if (key.startsWith('/data/') && !key.startsWith('/data/payments/')) {
+    if (key.startsWith('/data/')) {
       key = key.substring(6)
     }
 


### PR DESCRIPTION
Checked with aws ls and payments folder exists, it is just the data folder that doesn't exist so we only need to remove that.