### PR TITLE
VB-1287: Catch and throw unhandled promise rejections (GET /claim/:claimId)

### DIFF
--- a/app/routes/claim/view-claim.js
+++ b/app/routes/claim/view-claim.js
@@ -47,7 +47,7 @@ let claimDeductions
 
 module.exports = function (router) {
   // GET
-  router.get('/claim/:claimId', function (req, res) {
+  router.get('/claim/:claimId', function (req, res, next) {
     const allowedRoles = [
       applicationRoles.CLAIM_ENTRY_BAND_2,
       applicationRoles.CLAIM_PAYMENT_BAND_3,
@@ -56,6 +56,7 @@ module.exports = function (router) {
     ]
     authorisation.hasRoles(req, allowedRoles)
     return renderViewClaimPage(req.params.claimId, req, res)
+      .catch(error => next(error))
   })
 
   // APVS0246 Need Clarification on who can do this


### PR DESCRIPTION
Catch unhandled promise rejections on `GET /claim/:claimId` route and throw them to the Express error handler. This means there will be a 500 page rather than the app crashing and restarting.

(Background: when the app was running Node 12, unhandled promise rejections were just warnings. Since upgrading to Node 16 [the default](https://nodejs.org/api/cli.html#--unhandled-rejectionsmode) is now to throw them as uncaught exceptions. This could be overridden to restore the previous behaviour with `--unhandled-rejections=warn` but this just means the request hangs rather than crashes.)