### PR TITLE
Fixes dashboard tile layout

### DIFF
--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -60,7 +60,7 @@
   attributes: {
     'aria-label': 'Pending'
   },
-  classes: 'column-one-third',
+  classes: 'govuk-grid-column-one-third',
   items: [{
     html: '<h2 class="govuk-heading-l govuk-!-margin-bottom-2">' + pendingCount + '</h2>
     <p class="govuk-body">Pending</p>',
@@ -72,7 +72,7 @@
   attributes: {
     'aria-label': 'In Progress'
   },
-  classes: 'column-one-third',
+  classes: 'govuk-grid-column-one-third',
   items: [{
     html: '<h2 class="govuk-heading-l govuk-!-margin-bottom-2">' + inProgressCount + '</h2>
     <p class="govuk-body">In Progress</p>',
@@ -84,7 +84,7 @@
   attributes: {
     'aria-label': 'Paid Count'
   },
-  classes: 'column-one-third',
+  classes: 'govuk-grid-column-one-third',
   items: [{
     html: '<h2 class="govuk-heading-l govuk-!-margin-bottom-2">' + paidCount + '</h2>
     <p class="govuk-body">Paid</p>',
@@ -96,7 +96,7 @@
   attributes: {
     'aria-label': 'Auto Approved'
   },
-  classes: 'column-one-third',
+  classes: 'govuk-grid-column-one-third',
   items: [{
     html: '<h2 class="govuk-heading-l govuk-!-margin-bottom-2">' + autoApprovedCount + '</h2>
     <p class="govuk-body">Auto Approved</p>',
@@ -108,7 +108,7 @@
   attributes: {
     'aria-label': 'Manually Approved'
   },
-  classes: 'column-one-third',
+  classes: 'govuk-grid-column-one-third',
   items: [{
     html: '<h2 class="govuk-heading-l govuk-!-margin-bottom-2">' + manuallyApprovedCount + '</h2>
     <p class="govuk-body">Manually Approved</p>',
@@ -120,7 +120,7 @@
   attributes: {
     'aria-label': 'Rejected'
   },
-  classes: 'column-one-third',
+  classes: 'govuk-grid-column-one-third',
   items: [{
     html: '<h2 class="govuk-heading-l govuk-!-margin-bottom-2">' + rejectedCount + '</h2>
     <p class="govuk-body">Rejected</p>',


### PR DESCRIPTION
Noticed during testing the dashboard page was not rendering the "tiles" correctly - this fix enforces the gov-uk class that was missing.